### PR TITLE
Add 'make installdeps' command

### DIFF
--- a/makefile
+++ b/makefile
@@ -29,3 +29,6 @@ PRODUCTS = \
 
 $(PRODUCTS): all
 	$(MAKE) -C src/installer $@
+
+installdeps:
+	apt-get install build-essential libsdl1.2-dev libsdl-mixer1.2-dev


### PR DESCRIPTION
Provide consistent method to ensure Debian-based build environments have the minimum required dependencies.

Tested on Ubuntu 15.10 and Raspbian.
