### PR TITLE
Fix warning: missing braces around initializer

### DIFF
--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -261,7 +261,7 @@ static void	FlakesUpdate(const UpdateState& u);
 
 
 float	CloudUVOffset[2][2] = { { 0, 0 }, { 0, 0 } };
-float	CloudSpeed[2][2] = { 0.02f, 0.01f };	// Defaults get overridden by config vars.
+float	CloudSpeed[2][2] = { { 0, 0 }, { 0, 0 } };	// Defaults get overridden by config vars.
 float	CloudUVRepeat[2] = { 3, 4 };	// Defaults get overridden by config var.
 const float	CLOUD_XZ = 50000;
 


### PR DESCRIPTION
Corrects warning identified by GCC and Clang:

```
weather.cpp:264:41: warning: missing braces around initializer
for ‘float [2]’ [-Wmissing-braces]
```

The initialized values are overwritten at runtime by these default values automatically. Thus the previous values, whilst incomplete, were also never utilized.
