### PR TITLE
Add ShowBoarderFeet debug configuration

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -134,6 +134,7 @@ console.
 | PerfTest                                       | Boolean     | Enable benchmark mode (requires PerfTestPath.dat) |
 | PlayerCameraMode                               | Integer     |                                                   |
 | RewindsAllowed                                 | Integer     |                                                   |
+| ShowBoarderFeet                                | Boolean     | Show boarder's feet friction points               |
 | ShowBoarderRays                                | Boolean     |                                                   |
 | ShowCacheUsage                                 | Boolean     |                                                   |
 | ShowCheckCode                                  | Boolean     |                                                   |

--- a/src/boarder.cpp
+++ b/src/boarder.cpp
@@ -620,29 +620,26 @@ public:
 			//xxxxxx
 		}
 
-/*
-		//xxxxxxxxx
-		glColor3f(1, 0, 0);
-		for (int i = 0; i < 2; i++) {
-			vec3	v = Foot[i].Location;
+		if (Config::GetBoolValue("ShowBoarderFeet")) {
+			//xxxxxxxxx Boarder feet friction points, for debugging
+			// Red stars
+			glColor3f(1, 0, 0);
+			for (int i = 0; i < 2; i++) {
+				vec3	v = Foot[i].Location;
 			
-			glBegin(GL_LINES);
-			glVertex3fv(v + vec3(0, 0.1, 0));
-			glVertex3fv(v + vec3(0, -0.1, 0));
-			glEnd();
+				glBegin(GL_LINES);
+				glVertex3fv(v + vec3(0, 0.1, 0));
+				glVertex3fv(v + vec3(0, -0.1, 0));
 
-			glBegin(GL_LINES);
-			glVertex3fv(v + vec3(0.1, 0, 0));
-			glVertex3fv(v + vec3(-0.1, 0, 0));
-			glEnd();
+				glVertex3fv(v + vec3(0.1, 0, 0));
+				glVertex3fv(v + vec3(-0.1, 0, 0));
 
-			glBegin(GL_LINES);
-			glVertex3fv(v + vec3(0, 0, 0.1));
-			glVertex3fv(v + vec3(0, 0, -0.1));
-			glEnd();
+				glVertex3fv(v + vec3(0, 0, 0.1));
+				glVertex3fv(v + vec3(0, 0, -0.1));
+				glEnd();
+			}
+			//xxxxxxxx
 		}
-		//xxxxxxxx
-*/
 	}
 
 


### PR DESCRIPTION
Provides `ShowBoarderFeet` debug configuration to mark the boarder's feet friction points with red stars.
