### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/avi_tools.cpp
+++ b/src/avi_tools.cpp
@@ -445,8 +445,12 @@ void	avi_stream::close()
 }
 
 
-void	avi_stream::open_chunk(char* fourcc)
-// Opens a new chunk, and starts it with the given four-character-code tag.
+/**
+ * Opens a new chunk, and starts it with the given four-character-code tag.
+ * @param fourcc Character code
+ */
+void
+avi_stream::open_chunk(const char* fourcc)
 {
 	// Chunk type.
 	fwrite(fourcc, 1, 4, fp);

--- a/src/avi_tools.hpp
+++ b/src/avi_tools.hpp
@@ -42,7 +42,7 @@ namespace avi_tools {
 		void	write_video_frame(uint32* pixels, int width, int height);
 		void	close();
 
-		void	open_chunk(char* fourcc);
+		void	open_chunk(const char* fourcc);
 		void	close_chunk();
 	};
 };

--- a/src/d3drender.cpp
+++ b/src/d3drender.cpp
@@ -1924,10 +1924,10 @@ void	Render::DrawLine(const Vertex& a, const Vertex& b)
 D3DTexture*	TextureList = 0;
 
 
-Texture*	Render::NewTexture(const char* FileOrResourceName)
+Texture*	Render::NewTexture(const char* Filename)
 // Creates a new texture and registers it.
 {
-	return new D3DTexture(FileOrResourceName);
+	return new D3DTexture(Filename);
 }
 
 

--- a/src/d3drender.cpp
+++ b/src/d3drender.cpp
@@ -253,8 +253,15 @@ namespace Render {
 		return DeviceCount;
 	}
 
-	char*	GetDeviceDescription(int device)
-	// Returns a string describing the specified device.
+	/**
+	 * Describe render device
+	 *
+	 * @param device Index of device
+	 *
+	 * @return String describing the specified device
+	 */
+	const char*
+	GetDeviceDescription(int device)
 	{
 		if (device < 0 || device >= DeviceCount) return "!invalid";
 		else return Device[device].Description;

--- a/src/gamegui/gg_audio.cpp
+++ b/src/gamegui/gg_audio.cpp
@@ -1283,9 +1283,15 @@ GG_Sound* createAuSound( char *sndFile )
 }
 
 
-GG_Sound* createSound( char *sndFile )
+/**
+ * Create sound from path, handling format automatically
+ *
+ * @param sndFile Path to file
+ */
+GG_Sound*
+createSound( char *sndFile )
 {
-  int   i = 0;
+  size_t   i = 0;
   char  ext[128] = "";
 
 

--- a/src/gamegui/gg_file.cpp
+++ b/src/gamegui/gg_file.cpp
@@ -379,7 +379,7 @@ class GG_FileRAM : public GG_File
 GG_File *GG_FileOpen( char *fileName, uint32 openMode )
 {
   GG_File  *f = null;
-  char    *modeStr;
+  const char    *modeStr;
   FILE    *fp = NULL;
   char    name[GGFILE_MAXNAMELEN*2] = "";
 

--- a/src/gamegui/gg_file.cpp
+++ b/src/gamegui/gg_file.cpp
@@ -100,7 +100,7 @@ class GG_FileC : public GG_File
       {
         return fwrite( buf, size, num, m_fp );
       }
-    int32 writeText( char *buf )
+    int32 writeText( const char *buf )
       {
         int32 len = strlen(buf);
         return fwrite( buf, len, 1, m_fp );
@@ -255,7 +255,7 @@ class GG_FileRAM : public GG_File
 
         return i;
       }
-    int32 writeText( char *buf )
+    int32 writeText( const char *buf )
       {
         int32 size = strlen(buf);
         if( m_pos + size < m_size )

--- a/src/gamegui/gg_file.cpp
+++ b/src/gamegui/gg_file.cpp
@@ -517,7 +517,8 @@ static GGF_Rval translateFindInfo( WIN32_FIND_DATA *findInfo,
 //  Static public functions
 //
 //
-GGF_Rval GG_File::setCurrentPath( char *str )
+GGF_Rval
+GG_File::setCurrentPath( const char *str )
 {
   if( str == null )
   {

--- a/src/gamegui/gg_file.h
+++ b/src/gamegui/gg_file.h
@@ -115,7 +115,7 @@ class GG_File
     virtual int32 read( void *buf, uint32 size, uint32 num ) = 0;
     virtual int32 write( void *buf, uint32 size ) = 0;
     virtual int32 write( void *buf, uint32 size, uint32 num ) = 0;
-    virtual int32 writeText( char *text ) = 0;
+    virtual int32 writeText( const char *text ) = 0;
         //  No string formatting provided, use sprintf or
         //  whatever to format strings beforehand
         //  (% signs are safe to use though)

--- a/src/gamegui/gg_file.h
+++ b/src/gamegui/gg_file.h
@@ -170,13 +170,14 @@ class GG_File
     static GGF_Rval findNextFile( FileInfo *fileInfo );
     static GGF_Rval findClose( FileInfo *fileInfo );
 
-    //
-    //  setCurrentPath
-    //
-    //  - Sets the current path.  Calls to GG_File.. will
-    //    prefix any filenames with this path.
-    //
-    static GGF_Rval setCurrentPath( char *pathName );                // null == no path, GGFILE_MAXNAMELEN==maximum string length
+    /**
+     * Sets the current path.
+     *
+     * Calls to GG_File.. will prefix any filenames with this path.
+     *
+     * @param pathName Path to set. Maximum string length of GGFILE_MAXNAMELEN
+     */
+    static GGF_Rval setCurrentPath( const char *pathName );
     static GGF_Rval getCurrentPath( char *pathName, int maxChars );  // up to GGFILE_MAXNAMELEN chars may be needed
 };
 

--- a/src/gamegui/gg_log.c
+++ b/src/gamegui/gg_log.c
@@ -22,7 +22,8 @@ static char GG_LogFileName[] = "gamegui.log";
 static int GG_LogStarted = 0;
 
 
-void GG_logStr( char *buf )
+void
+GG_logStr( const char *buf )
 {
   FILE *fp;
 

--- a/src/gamegui/gg_log.cpp
+++ b/src/gamegui/gg_log.cpp
@@ -41,7 +41,8 @@ static char GG_LogFileName[] = "gamegui.log";
 static int GG_LogStarted = 0;
 
 
-void GG_logStr( char *buf )
+void
+GG_logStr( const char *buf )
 {
 #ifndef NDEBUG
   FILE *fp;

--- a/src/gamegui/gg_log.h
+++ b/src/gamegui/gg_log.h
@@ -41,7 +41,7 @@
 extern "C" {
 #endif
 
-void GG_logStr( char *buf );
+void GG_logStr( const char *buf );
 
 
 //  To control logging via a compiler switch, use

--- a/src/gamegui/gg_string.cpp
+++ b/src/gamegui/gg_string.cpp
@@ -191,13 +191,20 @@ bool GG_String::getQuote( char *str, char *quote )
 }
 
 
-//  Skip whitespace in str, compare the following characters with
-//  null-terminated wrd, return true on exact match
-//
-bool GG_String::cmpFirstWord( char *str, char *wrd )
+/**
+ * Skip whitespace in str, compare the following characters with
+ * null-terminated wrd
+ *
+ * @param str String to skip whitespace
+ * @param wrd String to compare against
+ *
+ * @return True on exact match
+ */
+bool
+GG_String::cmpFirstWord( char *str, char *wrd )
 {
   char *p = skipWhiteSpace(str);
-  int  wrdLen = strlen(wrd);
+  size_t  wrdLen = strlen(wrd);
 
   if( wrdLen <= strlen(p) )
     if( memcmp( p, wrd, wrdLen ) == 0 )

--- a/src/gamegui/gg_string.cpp
+++ b/src/gamegui/gg_string.cpp
@@ -214,7 +214,18 @@ GG_String::cmpFirstWord( char *str, char *wrd )
 }
 
 
-bool GG_String::cmpWord( char *str, char *wrd, uint32 wrdId )
+/**
+ * Skip wrdId number of words in str, then compare the following characters
+ * with null-terminated wrd
+ *
+ * @param str String to skip wrdId number of words
+ * @param wrd String to compare against
+ * @param wrdId Number of words in str to skip
+ *
+ * @return True on exact match
+ */
+bool
+GG_String::cmpWord( char *str, char *wrd, uint32 wrdId )
 {
   char    *p = str;
   uint32  wrdCount = 1;
@@ -225,7 +236,7 @@ bool GG_String::cmpWord( char *str, char *wrd, uint32 wrdId )
   if( p == null )
     return false;
 
-  int wrdLen = strlen(wrd);
+  size_t wrdLen = strlen(wrd);
 
   if( wrdLen <= strlen(p) )
     if( memcmp(wrd, p, wrdLen) == 0 )

--- a/src/gamegui/gg_string.h
+++ b/src/gamegui/gg_string.h
@@ -102,7 +102,7 @@ class GG_String
       return m_capacity;
     }
 
-    inline int length(void)
+    inline size_t length(void)
     {
       return strlen(m_str);
     }

--- a/src/gamegui/gg_string.h
+++ b/src/gamegui/gg_string.h
@@ -210,9 +210,6 @@ class GG_String
     }
 
 
-    //  Skip whitespace in str, compare the following characters with
-    //  null-terminated wrd, return true on exact match
-    //
     static bool cmpFirstWord( char *str, char *wrd );
 
     inline bool cmpFirstWord( char *wrd )

--- a/src/linuxsound.cpp
+++ b/src/linuxsound.cpp
@@ -154,12 +154,19 @@ int	sdl_volume(float vol)
 }
 
 
-int	Play(char* ResourceName, const Controls& Parameters)
-// Plays the sound specified by the given resource name.  The return value
-// is an "event id" for the sound event started by this call.  This id can be
-// used later in calls to Sound::Adjust() or Sound::Release() to change the
-// sound's parameters.
-// Returns 0 on failure.
+/**
+ * Plays the sound specified by the given resource name.
+ *
+ * @param ResourceName Filename
+ * @param Parameters   Controls to specific parameters
+ *
+ * @return An "event id" for the sound event started by this call. This id can
+ * be used later in calls to Sound::Adjust() or Sound::Release() to change the
+ * sound's parameters.
+ * @return 0 on failure.
+ */
+int
+Play(const char* ResourceName, const Controls& Parameters)
 {
 	if (!IsOpen) return 0;
 

--- a/src/macosxoglrender.cpp
+++ b/src/macosxoglrender.cpp
@@ -249,9 +249,15 @@ GetDriverName(int index)
   return "OpenGL";
 }
 
-	
-char*	GetDriverComment(int index)
-// Returns extra info about the specified driver.
+/**
+ * Returns extra information about the specified driver
+ *
+ * @param index Index of device
+ *
+ * @return String of extra information
+ */
+const char*
+GetDriverComment(int index)
 {
   return "---";
 }

--- a/src/macosxoglrender.cpp
+++ b/src/macosxoglrender.cpp
@@ -339,7 +339,7 @@ const int	DesiredColorDepth = 16;
 
   // windows specific code removed too
 
-void	CheckOGLError(char* FuncName);
+void	CheckOGLError(const char* FuncName);
 
 
 HGLRC	RenderingContext = 0;
@@ -1246,9 +1246,16 @@ void	WriteScreenshotFilePPM(const char* filename)
 }
 
 
-void	CheckOGLError(char* FuncName)
-// Checks for OpenGL error codes.  If there's an error, throws an exception
-// with an error message which includes the given function name.
+/**
+ * Checks for OpenGL error codes.
+ *
+ * If there's an error, throws an exception with an error message which includes
+ * the given function name.
+ *
+ * @param FuncName   Provide callee function for logging purposes
+ */
+void
+CheckOGLError(const char* FuncName)
 {
 	GLenum	error = glGetError();
 	if (error == GL_NO_ERROR) return;

--- a/src/macosxoglrender.cpp
+++ b/src/macosxoglrender.cpp
@@ -213,10 +213,20 @@ void SetWindowFullscreen(bool fullscreen){
 #endif
 
 int	GetDeviceCount() { return 1; }
-char*	GetDeviceDescription(int device)
+
+/**
+ * Describe render device
+ *
+ * @param device Index of device
+ *
+ * @return String describing the specified device
+ */
+const char*
+GetDeviceDescription(int device)
 {
 	return "---";
 }
+
 int	GetCurrentDevice() { return 0; }
 
 

--- a/src/macosxoglrender.cpp
+++ b/src/macosxoglrender.cpp
@@ -236,9 +236,15 @@ int	GetDriverCount(int device)
   return 1;
 }
 
-
-char*	GetDriverName(int index)
-// Returns the name of the specified driver.
+/**
+ * Get name of driver
+ *
+ * @param index Index of device
+ *
+ * @return String name of the specified driver.
+ */
+const char*
+GetDriverName(int index)
 {
   return "OpenGL";
 }

--- a/src/macosxsound.cpp
+++ b/src/macosxsound.cpp
@@ -267,7 +267,7 @@ Mix_Music *music = NULL;
 
 void PlayMusicFile(int TrackID){
 
-  char *music_directory = "../music/";
+  const char *music_directory = "../music/";
 
   std::vector<std::string> song = MacOSX::GetMusicFiles(music_directory);
 

--- a/src/macosxsound.cpp
+++ b/src/macosxsound.cpp
@@ -152,12 +152,19 @@ int	sdl_volume(float vol)
 int macosx_cd_status = CD_STOP;
 
 
-int	Play(char* ResourceName, const Controls& Parameters)
-// Plays the sound specified by the given resource name.  The return value
-// is an "event id" for the sound event started by this call.  This id can be
-// used later in calls to Sound::Adjust() or Sound::Release() to change the
-// sound's parameters.
-// Returns 0 on failure.
+/**
+ * Plays the sound specified by the given resource name.
+ *
+ * @param ResourceName Filename
+ * @param Parameters   Controls to specific parameters
+ *
+ * @return An "event id" for the sound event started by this call. This id can
+ * be used later in calls to Sound::Adjust() or Sound::Release() to change the
+ * sound's parameters.
+ * @return 0 on failure.
+ */
+int
+Play(const char* ResourceName, const Controls& Parameters)
 {
 	if (!IsOpen) return 0;
 
@@ -179,7 +186,6 @@ int	Play(char* ResourceName, const Controls& Parameters)
 	}
 
 	return channel + 1;
-  return 0;
 }
 
 

--- a/src/macosxworkaround.cpp
+++ b/src/macosxworkaround.cpp
@@ -133,7 +133,7 @@ vector<string> GetMusicFiles(const char* dir){
 
   void GenerateMusicIndex(){
     
-    char* filename = "/tmp/cdaindex.txt";
+    const char* filename = "/tmp/cdaindex.txt";
 
     ofstream outfile(filename);
 

--- a/src/macosxworkaround.cpp
+++ b/src/macosxworkaround.cpp
@@ -81,7 +81,7 @@ const char* whoami(){
   int number_of_music_files = -1;
   vector<string> music_files;
 
-  int GetMusicCount(char* dir){
+  int GetMusicCount(const char* dir){
 
     // this avoids searching for files all the time
     if (music_files.size() == 0 && number_of_music_files < 0)
@@ -92,7 +92,7 @@ const char* whoami(){
     return music_files.size();
   }
 
-vector<string> GetMusicFiles(char* dir){
+vector<string> GetMusicFiles(const char* dir){
   if (music_files.size() > 0)
     return music_files;
   

--- a/src/macosxworkaround.hpp
+++ b/src/macosxworkaround.hpp
@@ -27,8 +27,8 @@ namespace MacOSX {
   const char* PlayerData_directory();
   const char* whoami();
 
-  int GetMusicCount(char* dir);
-  std::vector<std::string> GetMusicFiles(char* dir);
+  int GetMusicCount(const char* dir);
+  std::vector<std::string> GetMusicFiles(const char* dir);
   void GenerateMusicIndex();
 
 }

--- a/src/oglrender.cpp
+++ b/src/oglrender.cpp
@@ -338,9 +338,15 @@ GetDriverName(int index)
 #endif // not LINUX
 }
 
-	
-char*	GetDriverComment(int index)
-// Returns extra info about the specified driver.
+/**
+ * Returns extra information about the specified driver
+ *
+ * @param index Index of device
+ *
+ * @return String of extra information
+ */
+const char*
+GetDriverComment(int index)
 {
 #ifdef LINUX
 	return "---";

--- a/src/oglrender.cpp
+++ b/src/oglrender.cpp
@@ -694,7 +694,7 @@ void	FindDesiredPixelFormat()
 #endif // not LINUX
 
 
-void	CheckOGLError(char* FuncName);
+void	CheckOGLError(const char* FuncName);
 
 
 HGLRC	RenderingContext = 0;
@@ -1660,9 +1660,16 @@ void	WriteScreenshotFilePPM(const char* filename)
 }
 
 
-void	CheckOGLError(char* FuncName)
-// Checks for OpenGL error codes.  If there's an error, throws an exception
-// with an error message which includes the given function name.
+/**
+ * Checks for OpenGL error codes.
+ *
+ * If there's an error, throws an exception with an error message which includes
+ * the given function name.
+ *
+ * @param FuncName   Provide callee function for logging purposes
+ */
+void
+CheckOGLError(const char* FuncName)
 {
 	GLenum	error = glGetError();
 	if (error == GL_NO_ERROR) return;

--- a/src/oglrender.cpp
+++ b/src/oglrender.cpp
@@ -320,8 +320,15 @@ int	GetDriverCount(int device)
 }
 
 
-char*	GetDriverName(int index)
-// Returns the name of the specified driver.
+/**
+ * Get name of driver
+ *
+ * @param index Index of device
+ *
+ * @return String name of the specified driver.
+ */
+const char*
+GetDriverName(int index)
 {
 #ifdef LINUX
 	return "OpenGL";

--- a/src/oglrender.cpp
+++ b/src/oglrender.cpp
@@ -292,10 +292,20 @@ ModeInfo	Mode[MAX_MODES] = {
 
 	
 int	GetDeviceCount() { return 1; }
-char*	GetDeviceDescription(int device)
+
+/**
+ * Describe render device
+ *
+ * @param device Index of device
+ *
+ * @return String describing the specified device
+ */
+const char*
+GetDeviceDescription(int device)
 {
 	return "---";
 }
+
 int	GetCurrentDevice() { return 0; }
 
 

--- a/src/render.hpp
+++ b/src/render.hpp
@@ -107,7 +107,7 @@ namespace Render {
 		int	Height, Width, TexelCount;
 	};
 	class	NewTextureError : public RenderError {};
-	Texture*	NewTexture(const char* FileOrResourceName, bool NeedAlpha, bool MakeMIPMaps, bool Tile, bool AlphaFadedMIPMaps = false);
+	Texture*	NewTexture(const char* Filename, bool NeedAlpha, bool MakeMIPMaps, bool Tile, bool AlphaFadedMIPMaps = false);
 	Texture*	NewTextureFromBitmap(bitmap32* b, bool NeedAlpha, bool MakeMIPMaps, bool Tile, bool AlphaFadedMIPMaps = false);
 	void	DeleteTexture(Texture* t);
 	void	ClearTextures();	// For deleting all the textures.

--- a/src/render.hpp
+++ b/src/render.hpp
@@ -61,7 +61,7 @@ namespace Render {
 	int	GetCurrentDevice();
 	
 	int	GetDriverCount(int device);
-	char*	GetDriverName(int DriverIndex);
+	const char*	GetDriverName(int DriverIndex);
 	char*	GetDriverComment(int DriverIndex);
 	int	GetCurrentDriver(int device);
 	int	AddNewDriver();

--- a/src/render.hpp
+++ b/src/render.hpp
@@ -57,7 +57,7 @@ namespace Render {
 
 	// Driver/device control.
 	int	GetDeviceCount();
-	char*	GetDeviceDescription(int DeviceIndex);
+	const char*	GetDeviceDescription(int DeviceIndex);
 	int	GetCurrentDevice();
 	
 	int	GetDriverCount(int device);

--- a/src/render.hpp
+++ b/src/render.hpp
@@ -62,7 +62,7 @@ namespace Render {
 	
 	int	GetDriverCount(int device);
 	const char*	GetDriverName(int DriverIndex);
-	char*	GetDriverComment(int DriverIndex);
+	const char*	GetDriverComment(int DriverIndex);
 	int	GetCurrentDriver(int device);
 	int	AddNewDriver();
 	void	SetDriverInfo(int index, const char* Name, const char* Comment);

--- a/src/sound.hpp
+++ b/src/sound.hpp
@@ -56,7 +56,7 @@ namespace Sound {
 		}
 	};
 	
-	int	Play(char* ResourceName, const Controls& Parameters);
+	int	Play(const char* ResourceName, const Controls& Parameters);
 	void	Adjust(int EventID, const Controls& NewParameters);
 	void	Release(int EventID);	// Use this to release a looped sound (or to stop short a discrete sound).
 	int	GetStatus(int EventID);

--- a/src/surfaceshader.cpp
+++ b/src/surfaceshader.cpp
@@ -95,8 +95,8 @@ int	SurfaceTypeCount = 0;
 
 // added "surfaceInitInfoType" to remove g++ 4.0 compiler errors
 struct surfaceInitInfoType {
-	char*	BitmapName0;
-	char*	BitmapName1;
+	const char*	BitmapName0;
+	const char*	BitmapName1;
 	PhysicalInfo	Physical;
 } SurfaceInitInfo[] = {
 	{ "forest0.psd", "forest1.psd", { 0, 0.70f, 0, 0, 1, 0.5f } },
@@ -126,8 +126,13 @@ bitmap32*	SubFilter(bitmap32* source)
 }
 
 
-void	InitSurfaceImages(SurfaceTileInfo* s, char* ImageFileName)
-// Creates a new surface type using the given filename as the image.
+/**
+ * Creates a new surface type using the given filename as the image.
+ * @param s             SurfaceTileInfo type to output
+ * @param ImageFileName Filename
+ */
+static void
+InitSurfaceImages(SurfaceTileInfo* s, const char* ImageFileName)
 {
 	bitmap32*	b = PSDRead::ReadImageData32(ImageFileName);
 	if (b == NULL) {
@@ -246,16 +251,15 @@ void	ResetSurfaceShader()
 
 	// Load surfaces.
 	for (SurfaceTypeCount = 0; SurfaceTypeCount < MAX_SURFACE_TYPES; SurfaceTypeCount++) {
-		char*	bm = SurfaceInitInfo[SurfaceTypeCount].BitmapName0;
-		if (bm == NULL) break;
+		if (SurfaceInitInfo[SurfaceTypeCount].BitmapName0 == NULL) break;
 
 		Game::LoadingTick();
-		InitSurfaceImages(&SurfaceType[SurfaceTypeCount].Tile[0], bm);	// Init first tile bitmap.
-
-		bm = SurfaceInitInfo[SurfaceTypeCount].BitmapName1;
+		InitSurfaceImages(&SurfaceType[SurfaceTypeCount].Tile[0],
+		                  SurfaceInitInfo[SurfaceTypeCount].BitmapName0);	// Init first tile bitmap.
 		
 		Game::LoadingTick();
-		InitSurfaceImages(&SurfaceType[SurfaceTypeCount].Tile[1], bm);	// Init second tile bitmap.
+		InitSurfaceImages(&SurfaceType[SurfaceTypeCount].Tile[1],
+		                  SurfaceInitInfo[SurfaceTypeCount].BitmapName1);	// Init second tile bitmap.
 		
 		SurfaceType[SurfaceTypeCount].Physical = SurfaceInitInfo[SurfaceTypeCount].Physical;	// Copy physical params.
 	}

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -51,7 +51,9 @@ Mode	DeferredMode = NONE;
 
 
 ::Render::Texture*	CursorIcon[CURSOR_TYPE_COUNT];
-char*	IconName[CURSOR_TYPE_COUNT] = {
+
+const char*
+IconName[CURSOR_TYPE_COUNT] = {
 	"arrow-cursor.psd",
 	"cross-cursor.psd",
 	"mapcursor.psd",

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -275,8 +275,9 @@ void	SetMode(Mode mode, int Ticks, int player_index)
 	// sitting around).
 	Input::ClearMouseEvents();
   
-	// Bjorn debugging / understanding what happends
-	char* mode_names[] = 
+	/*
+	 * Bjorn debugging / understanding what happens
+	const char* mode_names[] =
 		{ "NONE","ATTRACT","PLAYERQUERY","PLAYERNAME","PLAYERSELECT","MAINMENU",
 		  "SELECTMOUNTAIN","SELECTRUN","SHOWRUNINFO","RUNFLYOVER",
 		  "COUNTDOWN","RESUME","PLAYING","SHOWCRASH","CRASHQUERY","SHOWREWIND","SHOWFINISH",
@@ -287,12 +288,11 @@ void	SetMode(Mode mode, int Ticks, int player_index)
 		  "MULTIPLAYERQUERY","WAITING_FOR_OTHERS", 
 		  "MODECOUNT"};
   
-//   // Bjorn: debugging
-//   std::cout << "oldmode = " << mode_names[CurrentMode[player_index]] 
-// 	    << ", newmode = " << mode_names[mode] 
-// 	    << " for player_index " << player_index << std::endl;
-  
-  
+	std::cout << "oldmode = " << mode_names[CurrentMode[player_index]]
+	    << ", newmode = " << mode_names[mode]
+	    << " for player_index " << player_index << std::endl;
+	*/
+
 	ModeHandler*	OldHandler = Handler[CurrentMode[player_index]];
 	ModeHandler*	NewHandler = Handler[mode];
 

--- a/src/uiplayback.cpp
+++ b/src/uiplayback.cpp
@@ -62,7 +62,7 @@
 
 const int	BUTTON_COUNT = 8;
 struct ButtonInfo {
-	char*	Name;
+	const char*	Name;
 	// key id
 } ButtonData[BUTTON_COUNT] = {
 	{ "vcr_load.ggm" },

--- a/src/winsound.cpp
+++ b/src/winsound.cpp
@@ -226,11 +226,19 @@ void	SetSFXVolume(uint8 vol)
 }
 
 
-int	Play(char* ResourceName, const Controls& Parameters)
-// Plays the sound specified by the given resource name.  The return value
-// is an "event id" for the sound event started by this call.  This id can be
-// used later in calls to Sound::Adjust() or Sound::Release() to change the
-// sound's parameters.
+/**
+ * Plays the sound specified by the given resource name.
+ *
+ * @param ResourceName Filename
+ * @param Parameters   Controls to specific parameters
+ *
+ * @return An "event id" for the sound event started by this call. This id can
+ * be used later in calls to Sound::Adjust() or Sound::Release() to change the
+ * sound's parameters.
+ * @return 0 on failure.
+ */
+int
+Play(const char* ResourceName, const Controls& Parameters)
 {
 	if (!IsOpen) return -1;
 	


### PR DESCRIPTION
Significantly reduce the number of build warnings, whilst also improving Doxygen documentation.

On a Clang 3.4 build with `make DEBUG=1` the following improvements are seen:
- 198 less lines of build output.
- 147 less build warnings.

A majority of the remaining build warnings relate to third party libraries, such as Lua 3.2 which has known warnings for its lack of `const char*` specifiers.
