### PR TITLE
Fix OOB write & read on command_line[]

### DIFF
--- a/src/linuxmain.cpp
+++ b/src/linuxmain.cpp
@@ -104,7 +104,7 @@ int	main(int argc, char** argv)
 	try {
 		// Concatenate all the args into one big string.  It'll be re-parsed into Lua
 		// assignments by Main::Open().
-		int	cl_size = 0;
+		int	cl_size = 1;
 		int	i;
 		for (i = 1; i < argc; i++) {
 			cl_size += strlen(argv[i]) + 1;


### PR DESCRIPTION
Found with valgrind.

```
==10105== Invalid write of size 2
==10105==    at 0x40586B: main (linuxmain.cpp:116)
==10105==  Address 0xda95358 is 24 bytes inside a block of size 25 alloc'd
==10105==    at 0x4C2C7FC: operator new[](unsigned long) (vg_replace_malloc.c:422)
==10105==    by 0x4057E3: main (linuxmain.cpp:112)
==10105==

==11124== Invalid read of size 1
==11124==    at 0x4214E8: Config::ProcessOption(char const*) (config.cpp:93)
==11124==    by 0x42183A: Config::ProcessCommandLine(char const*) (config.cpp:200)
==11124==    by 0x437093: Main::Open(char*) (main.cpp:173)
==11124==    by 0x405887: main (linuxmain.cpp:119)
==11124==  Address 0xda9536f is 0 bytes after a block of size 47 alloc'd
==11124==    at 0x4C2C7FC: operator new[](unsigned long) (vg_replace_malloc.c:422)
==11124==    by 0x4057E3: main (linuxmain.cpp:112)
==11124==
```
