### PR TITLE
Improve path separator abstraction

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -340,8 +340,17 @@ void	ClearMountain()
 static GG_Player*	LoadingPlayer = NULL;
 
 
-void	LoadMountain(const char* MountainName)
-// Loads mountain info from the file formed by adding ".srt" to the given mountain name.
+/**
+ * Loads mountain info
+ *
+ * Settings loaded from file formed by adding ".srt" to the given mountain name
+ * within data/MountainName/.
+ * Setup a number of default settings and run preload and postload Lua scripts.
+ *
+ * @param MountainName Name of mountain to load
+ */
+void
+LoadMountain(const char* MountainName)
 {
 	GameLoop::AutoPauseInput	autoPause;	// Turn off the input thread inside this function.
 
@@ -375,7 +384,11 @@ void	LoadMountain(const char* MountainName)
 	{
 		const int	SCRIPTFILE_MAXLEN = 1000;
 		char	scriptfile[SCRIPTFILE_MAXLEN];
-		snprintf(scriptfile, SCRIPTFILE_MAXLEN, "../data/%s/preload.lua", MountainName);
+		snprintf(scriptfile, SCRIPTFILE_MAXLEN, ".." PATH_SEPARATOR
+							"data" PATH_SEPARATOR
+							"%s" PATH_SEPARATOR
+							"preload.lua",
+							MountainName);
 		lua_dofile(scriptfile);
 	}
 	
@@ -565,7 +578,11 @@ void	LoadMountain(const char* MountainName)
 	{
 		const int	SCRIPTFILE_MAXLEN = 1000;
 		char	scriptfile[SCRIPTFILE_MAXLEN];
-		snprintf(scriptfile, SCRIPTFILE_MAXLEN, "../data/%s/postload.lua", MountainName);
+		snprintf(scriptfile, SCRIPTFILE_MAXLEN, ".." PATH_SEPARATOR
+							"data" PATH_SEPARATOR
+							"%s" PATH_SEPARATOR
+							"postload.lua",
+							MountainName);
 		lua_dofile(scriptfile);
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,7 +149,7 @@ void	Open(char* CommandLine)
 	Config::SetBool("RecordMoviePause", true);
 	
 	// Read global preload script, if any.
-	lua_dofile("../data/preload.lua");
+	lua_dofile("preload.lua");
 
 	// Read values from config.txt.
 	FILE*	fp = fopen(".." PATH_SEPARATOR "config.txt", "r");

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -409,7 +409,7 @@ bool	Player::GetSavedPlayersAvailable()
 #ifdef MACOSX_CARBON
   DIR*  d = opendir(MacOSX::PlayerData_directory());
 #else  // not MACOSX_CARBON
-  DIR*	d = opendir("../PlayerData");
+  DIR*	d = opendir(".." PATH_SEPARATOR "PlayerData");
 #endif // not MACOSX_CARBON
 
   if (d) {

--- a/src/recording.cpp
+++ b/src/recording.cpp
@@ -363,13 +363,19 @@ static bool	MountainMatch(const char* MtnName, const char* RecName)
 }
 
 
-void	EnumerateRecordings(const char* MtnName, void (*callback)(const char* RecName))
-// Goes through each recording file, finds the ones which were made at
-// the given mountain, and passes each qualifying file name to the given
-// callback function.
+/**
+ * Goes through each recording file, finds the ones which were made at
+ * the given mountain, and passes each qualifying file name to the given
+ * callback function.
+ *
+ * @param MtnName Mountain name to filter for
+ * @param RecName Callback function
+ */
+void
+EnumerateRecordings(const char* MtnName, void (*callback)(const char* RecName))
 {
 #ifdef LINUX
-	DIR*	dir = opendir("../Recordings");
+	DIR*	dir = opendir(".." PATH_SEPARATOR "Recordings");
 	struct dirent*	ent;
 	while (ent = readdir(dir)) {
 		char*	filename = ent->d_name;

--- a/src/uiplayer.cpp
+++ b/src/uiplayer.cpp
@@ -187,7 +187,7 @@ public:
 #ifdef MACOSX_CARBON
 		DIR*	dir = opendir(MacOSX::PlayerData_directory());
 #else // not MACOSX_CARBON -> LINUX
-		DIR*	dir = opendir("../PlayerData");
+		DIR*	dir = opendir(".." PATH_SEPARATOR "PlayerData");
 #endif	      
 
 		struct dirent*	ent;
@@ -199,7 +199,10 @@ public:
 			}
 #else // not LINUX
 		_finddata_t	d;
-		long	handle = _findfirst("../PlayerData/*.srp", &d);
+		long	handle = _findfirst(".." PATH_SEPARATOR
+					    "PlayerData" PATH_SEPARATOR
+					    "*.srp",
+					    &d);
 		int	result = handle;
 		while (result != -1) {
 			char*	filename = d.name;


### PR DESCRIPTION
The engine provides `PATH_SEPARATOR` to ensure at compile time the correct folder path separator is used for the platform.

Improve cross platform support by utilizing `PATH_SEPARATOR` in remaining locations where missing.

Document functions touched.
