### PR TITLE
Improve automated benchmark mode

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -132,6 +132,7 @@ console.
 | LimitUpdateRate                                | Boolean     |                                                   |
 | MultiplayerEnabled                             | Boolean     | Enable local multiplayer mode menu (incomplete)   |
 | PerfTest                                       | Boolean     | Enable benchmark mode (requires PerfTestPath.dat) |
+| PerfTestExit                                   | Boolean     | Exit and print FPS to stdout after benchmark mode |
 | PlayerCameraMode                               | Integer     |                                                   |
 | RewindsAllowed                                 | Integer     |                                                   |
 | ShowBoarderFeet                                | Boolean     | Show boarder's feet friction points               |

--- a/src/perftest.cpp
+++ b/src/perftest.cpp
@@ -46,8 +46,13 @@ public:
 		CalculatedStats = false;
 	}
 
-	void	Update(const UpdateState& u)
-	// Advance the PerfTester along the path.
+	/**
+	 * Advance the PerfTester along the path.
+	 *
+	 * @param u State object.
+	 */
+	void
+	Update(const UpdateState& u)
 	{
 		if (StartTicks == 0) {
 			StartTicks = u.Ticks + 2000;
@@ -69,9 +74,11 @@ public:
 				int	TotalFrames = GameLoop::GetFrameNumber() - StartFrame;
 				float	AvgFrameRate = TotalFrames * 1000.0f / float(TotalTicks);
 
-//				Game::ShowPerfTestStats(AvgFrameRate);
-//				PerfTestUIInstance.ShowAverageFPS(AvgFrameRate);
 				ShowAverageFPS(AvgFrameRate);
+
+				if (Config::GetBoolValue("PerfTestExit") == true) {
+					Main::SetQuit(true);
+				}
 				
 				CalculatedStats = true;
 			}
@@ -167,12 +174,19 @@ public:
 		}
 	}
 
-	void	ShowAverageFPS(float AvgFPS)
-	// Tells this UI handler to start displaying the given fps value as the
-	// average fps.
+	/**
+	 * Tells this UI handler to start displaying the given FPS value as the
+	 * average FPS, and print value to stdout.
+	 *
+	 * @param AvgFPS Pre-calculated average FPS for relevant period of time.
+	 */
+	void
+	ShowAverageFPS(float AvgFPS)
 	{
 		ShowFPS = true;
 		AverageFPS = AvgFPS;
+
+		printf("Average FPS: %3.1f\n", AverageFPS);
 	}
 	
 } PerfTestUIInstance;


### PR DESCRIPTION
Provide a means for external tools to query the average FPS (print performance test output to stdout).
Provide a means for benchmark mode to exit automatically after a run.

Thus a benchmark could look like:

```
# Ensure mountain with PerfTestPath.dat is installed
$ make
$ ./soulride Fullscreen=0 OGLModeIndex=7 PerfTest=1 PerfTestExit=1
```
