### PR TITLE
Add open coded vec3 equality and inequality operator

### DIFF
--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -183,6 +183,28 @@ vec3::operator*=(float f)
 
 
 /**
+ * Equality operator.
+ */
+bool
+vec3::operator==(const vec3& rhs)
+{
+	return ( (*this).X() == rhs.X() &&
+		 (*this).Y() == rhs.Y() &&
+		 (*this).Z() == rhs.Z() );
+}
+
+
+/**
+ * Inequality operator.
+ */
+bool
+vec3::operator!=(const vec3& rhs)
+{
+	return !((*this) == rhs);
+}
+
+
+/**
  * Returns the length of *this.
  */
 float

--- a/src/geometry.hpp
+++ b/src/geometry.hpp
@@ -93,6 +93,8 @@ public:
 	vec3&	operator-=(const vec3& v);
 	vec3&	operator*=(float f);
 	vec3&	operator/=(float f) { return this->operator*=(1.0f / f); }
+	bool	operator==(const vec3& rhs);
+	bool	operator!=(const vec3& rhs);
 
 	float	magnitude() const;
 	float	sqrmag() const;


### PR DESCRIPTION
Provide an open coded vec3 equality operator, and then get the inequality operator cheaply.

This will be used in a subsequent patch series where it is indirectly used for more complex user-defined types.
