### PR TITLE
Set GModel and SModel attribute in constructor

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -1047,13 +1047,27 @@ MOriented::CheckForContact(Collide::ContactInfo* result, const Collide::SegmentI
 // GModel base class functions.
 //
 
+GModel::GModel()
+{
+	Radius = 0;
+}
+
+GModel::~GModel() {}
 
 void	GModel::Render(ViewState& s, int ClipHint)
 // Default null implementation.
 {
 }
 
-GModel::~GModel() {}
+
+//
+// SModel base class functions.
+//
+
+SModel::SModel()
+{
+	Radius = 0;
+}
 
 SModel::~SModel() {}
 

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -40,6 +40,7 @@ struct UpdateState;
 // Base class for geometric models.
 class GModel {
 public:
+	GModel();
 	virtual ~GModel();
 	
 	virtual void	Render(ViewState& s, int ClipHint);
@@ -65,6 +66,7 @@ public:
 // Base class for collision models.
 class SModel {	// "S" for "Solid"
 public:
+	SModel();
 	virtual ~SModel();
 	
 	virtual bool	CheckForContact(Collide::ContactInfo* result, const Collide::SegmentInfo& seg, const Collide::CylinderInfo& cyl) = 0;


### PR DESCRIPTION
Properly initializing a value for the Radius attribute(s) avoids valgrind reported warnings in the performance benchmark.
