### PR TITLE
Add additional screen resolution options

### DIFF
--- a/src/macosxoglrender.cpp
+++ b/src/macosxoglrender.cpp
@@ -174,7 +174,7 @@ void	WriteDriverList(const char* filename)
 // *** modes through the graphical user interface      ***
 
 // Maintain a list of available modes, and a currently selected mode.
-const int	MAX_MODES = 10;
+const int	MAX_MODES = 15;
 int	ModeCount = MAX_MODES;
 ModeInfo	Mode[MAX_MODES] = {
 //	{ 160, 120, 16, false },
@@ -188,6 +188,11 @@ ModeInfo	Mode[MAX_MODES] = {
 	{ 800, 600, 32, false },
 	{ 1024, 768, 32, false },
 	{ 1280, 1024, 32, false },
+	{ 1366, 768, 32, false },
+	{ 1440, 900, 32, false },
+	{ 1600, 900, 32, false },
+	{ 1920, 1080, 32, false },
+	{ 3840, 2160, 32, false },
 };
 
 #ifdef MACOSX

--- a/src/oglrender.cpp
+++ b/src/oglrender.cpp
@@ -274,7 +274,7 @@ void	WriteDriverList(const char* filename)
 
 
 // Maintain a list of available modes, and a currently selected mode.
-const int	MAX_MODES = 10;
+const int	MAX_MODES = 15;
 int	ModeCount = MAX_MODES;
 ModeInfo	Mode[MAX_MODES] = {
 //	{ 160, 120, 16, false },
@@ -288,6 +288,11 @@ ModeInfo	Mode[MAX_MODES] = {
 	{ 800, 600, 32, false },
 	{ 1024, 768, 32, false },
 	{ 1280, 1024, 32, false },
+	{ 1366, 768, 32, false },
+	{ 1440, 900, 32, false },
+	{ 1600, 900, 32, false },
+	{ 1920, 1080, 32, false },
+	{ 3840, 2160, 32, false },
 };
 
 	


### PR DESCRIPTION
Soulride hardcodes an array of available screen resolution options.

Increase this range, based on currently most common resolutions, per Steam's Hardware and Software Survey (June 2016).

Accessed through option `OGLModeIndex`.
