### PR TITLE
Add Coverity support via Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,21 @@ addons:
     - build-essential
     - libsdl1.2-dev
     - libsdl-mixer1.2-dev
+  coverity_scan:
+    project:
+      name: "Echelon9/soulride"
+      description: soulride
+    notification_email: rhyskidd@gmail.com
+    build_command: make
+    # must match TRAVIS_BRANCH check below
+    branch_pattern: coverity_scan
 
 # Use brew on OS X to install dependencies
 before_install:
+  # ugly hack; if running a coverity scan abort all except the 1st build
+  # note that branch_pattern & the TRAVIS_BRANCH check must match, unfortunately
+  # COVERITY_SCAN_BRANCH isn't defined until later in the build process
+  - if ([[ "${TRAVIS_JOB_NUMBER##*.}" != "1" ]] && [[ "$TRAVIS_BRANCH" == "coverity_scan" ]]); then false ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update               ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sdl sdl_mixer; fi
 
@@ -33,6 +45,10 @@ env:
   matrix:
     - DEBUG=1
     - DEBUG=0
+  global:
+    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
+    #   via the "travis encrypt" command using the project repo's public key
+    - secure: "j1w41BeWlSOGPuQsdZ+EXM3XfPL09UnddnDN1YS/obcSXFviDtNZEB2ekHG7y6cj4tuokh0wI/KtgJtq1p2IbSYNSbdy+QzvQvSrkFhyfVaBBp/NTkpVJFf4d0dtImZvzLmOuPdnBLdZtPRER81EJ4l6VPcosfzvIo4K4voAj+WbGjXOd50xTEJCNKpqdxqcCnhdcF8trW9glsy4DhKoe8VvBAc8TCeleqCTv/KFuvA+C5dSeHBOovVDfRVsGj8HhU/y4T0Y/WYqGmmdMyKX8CceyNKhVSJLDvjTc2MdaxF6sFQyg3ZkP+xW7rWbTAYNLGv/uH0/cU3DtmRq0RBRORubITYvxbGGfY1wVYpfDM0PWPENWW6rI+DU9NChtLYk9a4CAY0Y9xg+AiJvmGMJJiyLLd7oHbku38DavWfYvAFn3gJoxHVclZqZ5Z1iRYQUBzKOChTBJ/9KqhbxUM4nD3vknkwTxEMEnwqNId9NiJk7LNBFbbvsCkWVvFE5XxqcwqvqXq2zuJzmTrtN7EtqwSYdiwzIzKTuEmH58PHhIz04TDof5uYuM8RYS1cdVdzhudjANRLqzHiCJGzrHgqxmTeayeZYhAcjeJKwQuEkenHGlcVL6gRrsPsgP3H801SFyonQ5wNv8+ZGbTy6sDuylpwE0c7yVRbr7lUrwsPXgvs="
 
 #
 # Build and run test suite

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Soul Ride #
 
 [![Build Status](https://travis-ci.org/Echelon9/soulride.svg?branch=master)](https://travis-ci.org/Echelon9/soulride)
+[![Coverity Scan Build Status](https://img.shields.io/coverity/scan/9846.svg)](https://scan.coverity.com/projects/echelon9-soulride)
 [![GitHub License](https://img.shields.io/badge/license-GPLv2-blue.svg)](https://raw.githubusercontent.com/Echelon9/soulride/master/COPYING)
 
 Welcome to **Soul Ride**, a GPL physics-based snowboarding simulator, with an


### PR DESCRIPTION
Fixes #36. Coverity static analysis tool is free for open source projects.

Because there are weekly rate limits, Coverity scans will run on pushes to the coverity_scan branch only & only for the first build matrix environment. Contributors need not attempt to run Coverity on all Pull Requests.

Setup follows instructions at: https://scan.coverity.com/travis_ci
