### PR TITLE
Add GPL header to macosxworkaround files

### DIFF
--- a/src/macosxworkaround.cpp
+++ b/src/macosxworkaround.cpp
@@ -1,12 +1,25 @@
 /*
+    Copyright 2003 Bjorn Leffler
 
-Mac OS X workarounds
+    This file is part of The Soul Ride Engine, see http://soulride.com
 
-Author: Bjorn Leffler 31/8/2003
+    The Soul Ride Engine is free software; you can redistribute it
+    and/or modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2 of
+    the License, or (at your option) any later version.
 
-Released under the GPL etc...
+    The Soul Ride Engine is distributed in the hope that it will be
+    useful, but WITHOUT ANY WARRANTY; without even the implied
+    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the GNU General Public License for more details.
 
+    You should have received a copy of the GNU General Public License
+    along with Foobar; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
+
+// Mac OS X workarounds
+
 
 #ifdef MACOSX
 

--- a/src/macosxworkaround.hpp
+++ b/src/macosxworkaround.hpp
@@ -1,4 +1,22 @@
-// Add header here (GPL, etc...)
+/*
+    Copyright 2003 Bjorn Leffler
+
+    This file is part of The Soul Ride Engine, see http://soulride.com
+
+    The Soul Ride Engine is free software; you can redistribute it
+    and/or modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2 of
+    the License, or (at your option) any later version.
+
+    The Soul Ride Engine is distributed in the hope that it will be
+    useful, but WITHOUT ANY WARRANTY; without even the implied
+    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Foobar; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
 
 #ifdef MACOSX
 


### PR DESCRIPTION
Reflects authorship and GPL license.

Fixes Issue #46.
