### PR TITLE
Clean up OS X Carbon framework leftovers

### DIFF
--- a/readme-macosx.txt
+++ b/readme-macosx.txt
@@ -2,9 +2,9 @@
         Notes on the Mac OS X port 
 --------------------------------------------
 
-The MacOSX port is very similar to the Linux version. It is possible to only use X11 instead of Carbon/Cocoa, which is how I started. This port uses the native Carbon/Cocoa/OpenGL Frameworks. It also requires SDL and SDL_mixer to be installed or distributed with the game (see below).
+The MacOSX port is very similar to the Linux version. It is possible to only use X11 instead of Cocoa, which is how I started. This port uses the native Cocoa/OpenGL Frameworks. It also requires SDL and SDL_mixer to be installed or distributed with the game (see below).
 
-The Carbon version behaves like any MacOSX application. There is a clickable icon in the Finder and an initial options window.
+The Cocoa version behaves like any MacOSX application. There is a clickable icon in the Finder and an initial options window.
 
 Joysticks are supported through SDL. I believe most HID compliant USB joysticks will work.
 

--- a/src/highscore.cpp
+++ b/src/highscore.cpp
@@ -76,12 +76,7 @@ void	Read()
 	char	filename[200];
 
 	// Read the local high-score table.
-#ifndef MACOSX_CARBON
 	strcpy(filename, ".." PATH_SEPARATOR "PlayerData" PATH_SEPARATOR);
-#else
-	strcpy(filename, MacOSX::PlayerData_directory());
-	strcat(filename, PATH_SEPARATOR);
-#endif
 
 	strcat(filename, Game::GetCurrentMountain());
 	strcat(filename, ".local-hs.txt");
@@ -118,11 +113,7 @@ void	Read()
 
 #if 0
 	// Read the world high-score table.
-#ifndef MACOSX_CARBON
 	strcpy(filename, ".." PATH_SEPARATOR "PlayerData" PATH_SEPARATOR);
-#else
-	strcpy(filename, MacOSX::PlayerData_directory());
-#endif
 
 	strcat(filename, Game::GetCurrentMountain());
 	strcat(filename, ".world-hs.txt");
@@ -178,12 +169,9 @@ void	RegisterScore(const char* PlayerName, int run, int score)
 
 		// Write out the new dataset.
 		char	filename[200];
-#ifndef MACOSX_CARBON
+
 		strcpy(filename, ".." PATH_SEPARATOR "PlayerData" PATH_SEPARATOR);
-#else
-		strcpy(filename, MacOSX::PlayerData_directory());
-		strcat(filename, PATH_SEPARATOR);
-#endif
+
 		strcat(filename, Game::GetCurrentMountain());
 		strcat(filename, ".local-hs.txt");
 

--- a/src/macosxmain.hpp
+++ b/src/macosxmain.hpp
@@ -27,18 +27,10 @@
 #ifndef LINUXMAIN_HPP
 #define LINUXMAIN_HPP
 
-#include <Carbon/Carbon.h>
 
 namespace Main {
 	// Use of SDL has pretty much obviated any need for back-door OS info.
 };
 
-#ifdef MACOSX_CARBON
-void getWindowOptions();
-OSStatus SoulRideOptionWindowEventHandler(EventHandlerCallRef myHandler,
-                                                 EventRef event,
-                                                 void *userData);
-int	main2(int argc, char** argv);
-#endif // MACOSX_CARBON
 
 #endif // LINUXMAIN_HPP

--- a/src/macosxoglrender.cpp
+++ b/src/macosxoglrender.cpp
@@ -405,22 +405,11 @@ void	OpenOGL()
 	int	bpp = info->vfmt->BitsPerPixel;
 	int	flags = SDL_OPENGL | (Fullscreen ? SDL_FULLSCREEN : 0);
 
-#ifndef MACOSX_CARBON
 	// Set the video mode.
 	if (SDL_SetVideoMode(m.Width, m.Height, bpp, flags) == 0) {
 		Error e; e << "SDL_SetVideoMode() failed.";
 		throw e;
 	}
-#else
-	// Set the video mode in MacOSX Carbon Mode
-	if (SDL_SetVideoMode(GetWindowWidth(), 
-			     GetWindowHeight(), 
-			     GetWindowDepth(), 
-			     flags) == 0) {
-		RenderError e; e << "SDL_SetVideoMode() failed.";
-		throw e;
-	}
-#endif // MACOSX_CARBON
 
 
 #else // not LINUX

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,26 +74,20 @@ void	Open(char* CommandLine)
 	Config::Open();
 
 	// Set some default config variable values, now that Config:: is open.
-	// Graphical options are set using the Carbon GUI version for MacOSX
-#ifndef MACOSX_CARBON
 	Config::SetBool("Fullscreen", true);
 	Config::SetInt("OGLDriverIndex", 0);
 	Config::SetInt("OGLModeIndex", 1);
-#endif // MACOSX_CARBON
 	Config::SetFloat("ViewAngle", 97);
 	Config::SetFloat("TerrainMeshSlider", 6);
 	Config::SetInt("TextureDetailSlider", 6);
 	Config::SetFloat("MIPMapLODBias", 0);
 	Config::SetInt("OGLCheckErrorLevel", 1);
 
-// DefaultMountain is set using the Carbon GUI version for MacOSX
-#ifndef MACOSX_CARBON
 #ifdef STATIC_MOUNTAIN
 	Config::Set("DefaultMountain", STATIC_MOUNTAIN);
 #else
 	Config::Set("DefaultMountain", "Mammoth");
 #endif // STATIC_MOUNTAIN
-#endif // MACOSX_CARBON
 
 	Config::Set("Language", "en");
 	Config::SetBool("DetailMapping", true);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -104,24 +104,6 @@ static void	MakeFilename(char* buf, int bufsize, const char* Name)
 	char*	p = buf;
 	int count = 0;
 
-#ifdef MACOSX_CARBON
-
-	std::string filename("");
-	filename += MacOSX::PlayerData_directory();
-	filename += PATH_SEPARATOR;
-	filename += Name;
-	filename += ".srp";
-	
-	int stringlength;
-	if (filename.length() > bufsize-1)
-	  stringlength = filename.length();
-	else
-	  stringlength = bufsize-1;
-
-	strncpy(buf, filename.c_str(), stringlength);
-	
-#else // not MACOSX_CARBON
-
 	// Start with "..\PlayerData\".
 	const char*	s = ".." PATH_SEPARATOR "PlayerData" PATH_SEPARATOR;
 	while (count < bufsize-1) {
@@ -147,8 +129,6 @@ static void	MakeFilename(char* buf, int bufsize, const char* Name)
 	}
 
 	*p = 0;
-#endif // not MACOSX_CARBON
-	
 }
 
 
@@ -226,9 +206,6 @@ void	Save()
 	char	temp[1000];
 	MakeFilename(temp, 1000, Name);
 
-// MacOSX: We already know that PlayerData subdirectory exists.
-#ifndef MACOSX_CARBON
-
 	// Make sure PlayerData subdirectory exists.
 	chdir("..");
 	if (chdir("PlayerData") != 0) {
@@ -242,7 +219,6 @@ void	Save()
 		chdir("..");
 	}
 	chdir("data");
-#endif // not MACOSX_CARBON
 
 	// Try to open the file for output.
 	FILE* fp = fopen(temp, "wb");
@@ -406,11 +382,7 @@ bool	Player::GetSavedPlayersAvailable()
 
 #ifdef LINUX
 
-#ifdef MACOSX_CARBON
-  DIR*  d = opendir(MacOSX::PlayerData_directory());
-#else  // not MACOSX_CARBON
   DIR*	d = opendir(".." PATH_SEPARATOR "PlayerData");
-#endif // not MACOSX_CARBON
 
   if (d) {
 		struct dirent*	dir;

--- a/src/uiplayer.cpp
+++ b/src/uiplayer.cpp
@@ -39,11 +39,6 @@
 #include "main.hpp"
 #include "music.hpp"
 
-#ifdef MACOSX_CARBON
-#include <string>
-#include <iostream>
-#endif
-
 
 class PlayerQuery : public UI::ModeHandler {
 public:
@@ -184,11 +179,7 @@ public:
 
 #ifdef LINUX
 
-#ifdef MACOSX_CARBON
-		DIR*	dir = opendir(MacOSX::PlayerData_directory());
-#else // not MACOSX_CARBON -> LINUX
-		DIR*	dir = opendir(".." PATH_SEPARATOR "PlayerData");
-#endif	      
+		DIR*	dir = opendir(".." PATH_SEPARATOR "PlayerData");     
 
 		struct dirent*	ent;
 		while (ent = readdir(dir)) {


### PR DESCRIPTION
A number of documentation changes to reflect that the OS X Carbon API framework is no longer utilized due to its deprecation.

Remove ifdef'd out code blocks as well.
