### PR TITLE
Fallback to C++03, to avoid naming conflicts

### DIFF
--- a/makefile
+++ b/makefile
@@ -56,6 +56,6 @@ docs/doxygen/html/index.html: $(CPPSOURCES)
 ## cppcheck    : run static analysis on C++ source code
 cppcheck: $(CPPSOURCES)
 	cppcheck $(CPPSOURCES) --enable=all --platform=unix64 \
-	--std=c++11 --inline-suppr --quiet --force \
+	--std=c++03 --inline-suppr --quiet --force \
 	$(addprefix -I,$(INCLUDE_DIRS)) \
 	-I/usr/include -I/usr/include/linux

--- a/src/Makefile.macosx
+++ b/src/Makefile.macosx
@@ -37,7 +37,7 @@ SDL_MIXER_HEADERS = /Library/Frameworks/SDL_mixer.framework/Headers
 MACOSX_FRAMEWORKS = -framework Cocoa -framework OpenGL -framework SDL -framework SDL_mixer
 #-------------------------------------------------------------------------------
 
-cc = g++ -c
+cc = g++ -c -std=c++03
 debugflags = -g
 link = g++ $(debugflags) -fexceptions
 cflags = -I $(SDL_MIXER_HEADERS) $(shell sdl-config --cflags) -DLINUX=1 $(debugflags) -O3 -fomit-frame-pointer -fexceptions -ffast-math -DMACOSX

--- a/src/config.mak
+++ b/src/config.mak
@@ -110,7 +110,7 @@ else
 
 # GCC
 USE_SDL := 1
-CC := $(SOULRIDE_COMPILER)
+CC := $(SOULRIDE_COMPILER) -std=c++03
 AR := ar -r
 CC_OUT_FLAG := -o
 LIB_OUT_FLAG :=


### PR DESCRIPTION
Closes #59 

The game works after this, when using `gcc (GCC) 8.2.1 20181127`

---

Unfortunately, this creates a bit of discrepancy, as we'll compile with C++03, but we'll run cppcheck with C++11:

https://github.com/Echelon9/soulride/blob/34181730f1a0be8b4ea10694e4f4bcbca2049a21/makefile#L56-L61

If C++11 is meant to be the target version, we should probably keep #59 opened and change the function names to avoid these conflicts.